### PR TITLE
Add PedidoProduccion type and mock data

### DIFF
--- a/frontend/src/mocks/pedidosMock.ts
+++ b/frontend/src/mocks/pedidosMock.ts
@@ -1,0 +1,38 @@
+import { PedidoProduccion } from '../types/PedidoProduccion'
+
+export const pedidosMock: PedidoProduccion[] = [
+  {
+    id: '1',
+    numeroPedido: 'ACME-1001',
+    cliente: 'ACME Corp.',
+    maquinaImpresion: 'GIAVE',
+    desarrTexto: 'Bolsa de 30cm',
+    desarrNumero: 30,
+    metros: 1200,
+    tipoImpresion: 'Superficie',
+    capa: 'PET',
+    camisa: 'Roja',
+    fecha: '2024-07-09T08:30',
+    observaciones: 'Urgente',
+    secuenciaPedido: 1001,
+    etapaActual: 'Impresión GIAVE',
+    etapasSecuencia: ['Impresión GIAVE', 'Laminado', 'Rebobinado', 'Completado'],
+  },
+  {
+    id: '2',
+    numeroPedido: 'FOO-2002',
+    cliente: 'Foo S.L.',
+    maquinaImpresion: 'UTECO',
+    desarrTexto: 'Envase 50ml',
+    desarrNumero: 50,
+    metros: 5000,
+    tipoImpresion: 'Transparencia',
+    capa: 'PP',
+    camisa: 'Azul',
+    fecha: '2024-07-10T11:00',
+    observaciones: '',
+    secuenciaPedido: 2002,
+    etapaActual: 'Laminado',
+    etapasSecuencia: ['Impresión UTECO', 'Laminado', 'Perforado', 'Completado'],
+  },
+]

--- a/frontend/src/types/PedidoProduccion.ts
+++ b/frontend/src/types/PedidoProduccion.ts
@@ -1,0 +1,17 @@
+export interface PedidoProduccion {
+  id: string
+  numeroPedido: string
+  cliente: string
+  maquinaImpresion: string
+  desarrTexto: string
+  desarrNumero: number
+  metros: number
+  tipoImpresion: 'Superficie' | 'Transparencia'
+  capa: string
+  camisa: string
+  fecha: string
+  observaciones: string
+  secuenciaPedido: number
+  etapaActual: string
+  etapasSecuencia: string[]
+}


### PR DESCRIPTION
## Summary
- add interfaz `PedidoProduccion`
- incluir mock `pedidosMock`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e50343be88328b0ef84501a48a254