### PR TITLE
Implement drag and drop with dnd-kit

### DIFF
--- a/frontend/src/components/KanbanBoard.jsx
+++ b/frontend/src/components/KanbanBoard.jsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import KanbanColumn from './KanbanColumn'
+import { DndContext } from '@dnd-kit/core'
 import { pedidosMock } from '../mocks/pedidosMock'
 import { PedidoProduccion } from '../types/PedidoProduccion'
 
@@ -10,22 +11,35 @@ import { PedidoProduccion } from '../types/PedidoProduccion'
  * @returns {JSX.Element} Tablero Kanban completo.
  */
 function KanbanBoard({ pedidos }) {
-  const pedidosData = pedidos || pedidosMock
+  const [pedidosData, setPedidosData] = useState(pedidos || pedidosMock)
 
   const etapas = Array.from(
     new Set(pedidosData.flatMap((p) => p.etapasSecuencia))
   )
 
+  const handleDragEnd = (event) => {
+    const { active, over } = event
+    if (active && over && active.id !== over.id) {
+      setPedidosData((prev) =>
+        prev.map((pedido) =>
+          pedido.id === active.id ? { ...pedido, etapaActual: over.id } : pedido
+        )
+      )
+    }
+  }
+
   return (
-    <div className="flex gap-4 overflow-x-auto p-4">
-      {etapas.map((etapa) => (
-        <KanbanColumn
-          key={etapa}
-          etapa={etapa}
-          pedidos={pedidosData.filter((p) => p.etapaActual === etapa)}
-        />
-      ))}
-    </div>
+    <DndContext onDragEnd={handleDragEnd}>
+      <div className="flex gap-4 overflow-x-auto p-4">
+        {etapas.map((etapa) => (
+          <KanbanColumn
+            key={etapa}
+            etapa={etapa}
+            pedidos={pedidosData.filter((p) => p.etapaActual === etapa)}
+          />
+        ))}
+      </div>
+    </DndContext>
   )
 }
 

--- a/frontend/src/components/KanbanCard.jsx
+++ b/frontend/src/components/KanbanCard.jsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { useDraggable } from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
 import { PedidoProduccion } from '../types/PedidoProduccion'
 
 /**
@@ -8,8 +10,22 @@ import { PedidoProduccion } from '../types/PedidoProduccion'
  * @returns {JSX.Element} Tarjeta con información del pedido.
  */
 function KanbanCard({ pedido }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: pedido.id })
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.5 : 1,
+  }
+
   return (
-    <div className="bg-white rounded-lg shadow p-2 border">
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      style={style}
+      className="bg-white rounded-lg shadow p-2 border"
+    >
       <div className="font-semibold">{pedido.numeroPedido}</div>
       <div className="text-xs text-gray-600">{pedido.cliente}</div>
       <div className="text-xs">

--- a/frontend/src/components/KanbanColumn.jsx
+++ b/frontend/src/components/KanbanColumn.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import KanbanCard from './KanbanCard'
+import { useDroppable } from '@dnd-kit/core'
 import { PedidoProduccion } from '../types/PedidoProduccion'
 
 /**
@@ -9,8 +10,15 @@ import { PedidoProduccion } from '../types/PedidoProduccion'
  * @returns {JSX.Element} Columna con las tarjetas correspondientes.
  */
 function KanbanColumn({ etapa, pedidos }) {
+  const { setNodeRef, isOver } = useDroppable({ id: etapa })
+
   return (
-    <div className="bg-gray-100 rounded-xl p-3 min-w-[260px] shadow-md flex-1">
+    <div
+      ref={setNodeRef}
+      className={`bg-gray-100 rounded-xl p-3 min-w-[260px] shadow-md flex-1 ${
+        isOver ? 'bg-blue-100' : ''
+      }`}
+    >
       <h2 className="text-lg font-bold mb-2">{etapa}</h2>
       <div className="flex flex-col gap-2">
         {pedidos.map((pedido) => (


### PR DESCRIPTION
## Summary
- enable state updates in `KanbanBoard` and wrap columns with `DndContext`
- make `KanbanCard` draggable
- make `KanbanColumn` droppable

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e54d897d4832895de615782974bfb