### PR TITLE
Configura Express para servir frontend

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,25 +3,30 @@ require('dotenv').config();
 
 // 2. Importar la librería Express
 const express = require('express');
+// Importar utilidades para manejar rutas de archivos
+const path = require('path');
 
 // 3. Crear una instancia de la aplicación Express
 const app = express();
 
-// 4. Definir el puerto
+// 4. Servir archivos estáticos generados por el frontend
+app.use(express.static(path.join(__dirname, 'frontend', 'dist')));
+
+// 5. Redirigir cualquier ruta que no sea API al index.html del frontend
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
+});
+
+// 6. Definir el puerto
 // Heroku te asignará un puerto dinámicamente a través de una variable de entorno llamada PORT.
 // Si no existe (porque estás en tu máquina local), usará el puerto 3000.
 const PORT = process.env.PORT || 3000;
 
-// 5. Crear la ruta principal (endpoint)
-// Esto responde a las peticiones GET en la raíz de tu sitio (ej: https://mi-app.herokuapp.com/)
-app.get('/', (req, res) => {
-  res.send('¡Hola, Mundo desde Heroku!');
-});
 
-// 6. Exportar la aplicación para facilitar las pruebas
+// 7. Exportar la aplicación para facilitar las pruebas
 module.exports = app;
 
-// 7. Si el archivo se ejecuta directamente, iniciar el servidor
+// 8. Si el archivo se ejecuta directamente, iniciar el servidor
 if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`Servidor escuchando en el puerto ${PORT}`);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,10 +1,27 @@
 const request = require('supertest');
-const app = require('../index');
+const fs = require('fs');
+const path = require('path');
+let app;
+
+beforeAll(() => {
+  const distDir = path.join(__dirname, '..', 'frontend', 'dist');
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(distDir, 'index.html'),
+    '<!doctype html><html><body>Prueba</body></html>'
+  );
+  app = require('../index');
+});
+
+afterAll(() => {
+  const distDir = path.join(__dirname, '..', 'frontend', 'dist');
+  fs.rmSync(distDir, { recursive: true, force: true });
+});
 
 describe('Rutas del servidor', () => {
-  test('GET / responde con texto de bienvenida', async () => {
+  test('GET / devuelve el index del frontend', async () => {
     const respuesta = await request(app).get('/');
     expect(respuesta.statusCode).toBe(200);
-    expect(respuesta.text).toBe('¡Hola, Mundo desde Heroku!');
+    expect(respuesta.text).toContain('<!doctype html>');
   });
 });


### PR DESCRIPTION
## Summary
- servir archivos estáticos generados por el frontend
- redirigir las rutas no API hacia el `index.html` del frontend
- adaptar las pruebas unitarias al nuevo comportamiento

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e80b2b5688328b505831a24824377