### PR TITLE
Agregar ordenamiento sortable al tablero Kanban

### DIFF
--- a/frontend/src/components/KanbanBoard.jsx
+++ b/frontend/src/components/KanbanBoard.jsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react'
 import KanbanColumn from './KanbanColumn'
-import { DndContext } from '@dnd-kit/core'
+import { DndContext, closestCorners } from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
 import { pedidosMock } from '../mocks/pedidosMock'
 import { PedidoProduccion } from '../types/PedidoProduccion'
 
@@ -19,25 +24,48 @@ function KanbanBoard({ pedidos }) {
 
   const handleDragEnd = (event) => {
     const { active, over } = event
-    if (active && over && active.id !== over.id) {
+    if (!over) return
+
+    const activePedido = pedidosData.find((p) => p.id === active.id)
+    const overPedido = pedidosData.find((p) => p.id === over.id)
+
+    if (!activePedido || !overPedido) return
+
+    if (activePedido.etapaActual !== overPedido.etapaActual) {
       setPedidosData((prev) =>
-        prev.map((pedido) =>
-          pedido.id === active.id ? { ...pedido, etapaActual: over.id } : pedido
+        prev.map((p) =>
+          p.id === activePedido.id
+            ? { ...p, etapaActual: overPedido.etapaActual }
+            : p
         )
       )
+    } else {
+      const etapa = activePedido.etapaActual
+      const pedidosColumna = pedidosData.filter((p) => p.etapaActual === etapa)
+      const oldIndex = pedidosColumna.findIndex((p) => p.id === active.id)
+      const newIndex = pedidosColumna.findIndex((p) => p.id === over.id)
+      const nuevosPedidosColumna = arrayMove(pedidosColumna, oldIndex, newIndex)
+      const otrosPedidos = pedidosData.filter((p) => p.etapaActual !== etapa)
+      setPedidosData([...otrosPedidos, ...nuevosPedidosColumna])
     }
   }
 
   return (
-    <DndContext onDragEnd={handleDragEnd}>
+    <DndContext collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
       <div className="flex gap-4 overflow-x-auto p-4">
-        {etapas.map((etapa) => (
-          <KanbanColumn
-            key={etapa}
-            etapa={etapa}
-            pedidos={pedidosData.filter((p) => p.etapaActual === etapa)}
-          />
-        ))}
+        {etapas.map((etapa) => {
+          const pedidosEtapa = pedidosData.filter((p) => p.etapaActual === etapa)
+          return (
+            <SortableContext
+              key={etapa}
+              id={etapa}
+              items={pedidosEtapa.map((p) => p.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <KanbanColumn etapa={etapa} pedidos={pedidosEtapa} />
+            </SortableContext>
+          )
+        })}
       </div>
     </DndContext>
   )

--- a/frontend/src/components/KanbanCard.jsx
+++ b/frontend/src/components/KanbanCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useDraggable } from '@dnd-kit/core'
+import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { PedidoProduccion } from '../types/PedidoProduccion'
 
@@ -10,12 +10,20 @@ import { PedidoProduccion } from '../types/PedidoProduccion'
  * @returns {JSX.Element} Tarjeta con información del pedido.
  */
 function KanbanCard({ pedido }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useDraggable({ id: pedido.id })
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: pedido.id })
 
   const style = {
-    transform: CSS.Translate.toString(transform),
+    transform: CSS.Transform.toString(transform),
+    transition,
     opacity: isDragging ? 0.5 : 1,
+    cursor: 'grab',
   }
 
   return (

--- a/frontend/src/components/KanbanColumn.jsx
+++ b/frontend/src/components/KanbanColumn.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import KanbanCard from './KanbanCard'
-import { useDroppable } from '@dnd-kit/core'
 import { PedidoProduccion } from '../types/PedidoProduccion'
 
 /**
@@ -10,15 +9,9 @@ import { PedidoProduccion } from '../types/PedidoProduccion'
  * @returns {JSX.Element} Columna con las tarjetas correspondientes.
  */
 function KanbanColumn({ etapa, pedidos }) {
-  const { setNodeRef, isOver } = useDroppable({ id: etapa })
-
+  // Esta columna se gestiona como contexto ordenable desde KanbanBoard
   return (
-    <div
-      ref={setNodeRef}
-      className={`bg-gray-100 rounded-xl p-3 min-w-[260px] shadow-md flex-1 ${
-        isOver ? 'bg-blue-100' : ''
-      }`}
-    >
+    <div className="bg-gray-100 rounded-xl p-3 min-w-[260px] shadow-md flex-1">
       <h2 className="text-lg font-bold mb-2">{etapa}</h2>
       <div className="flex flex-col gap-2">
         {pedidos.map((pedido) => (


### PR DESCRIPTION
## Resumen
- implementar `useSortable` en `KanbanCard`
- simplificar `KanbanColumn` para integrarse con `SortableContext`
- actualizar `KanbanBoard` para ordenar tarjetas dentro de su columna
- conservar pruebas del servidor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e8d65a9dc8328b922420598513f3b