### PR TITLE
Add Kanban theme styles

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,8 +6,17 @@ import KanbanBoard from './components/KanbanBoard'
  */
 function App() {
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="p-4 border-b text-xl font-bold">
+    <div
+      className="min-h-screen"
+      style={{
+        backgroundColor: 'var(--color-background)',
+        color: 'var(--color-foreground)',
+      }}
+    >
+      <header
+        className="p-4 border-b text-xl font-bold"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
         Control de Producción
       </header>
       <KanbanBoard />

--- a/frontend/src/components/KanbanCard.jsx
+++ b/frontend/src/components/KanbanCard.jsx
@@ -24,7 +24,7 @@ function KanbanCard({ pedido }) {
       {...listeners}
       {...attributes}
       style={style}
-      className="bg-white rounded-lg shadow p-2 border"
+      className="kanban-card"
     >
       <div className="font-semibold">{pedido.numeroPedido}</div>
       <div className="text-xs text-gray-600">{pedido.cliente}</div>

--- a/frontend/src/components/KanbanColumn.jsx
+++ b/frontend/src/components/KanbanColumn.jsx
@@ -15,9 +15,7 @@ function KanbanColumn({ etapa, pedidos }) {
   return (
     <div
       ref={setNodeRef}
-      className={`bg-gray-100 rounded-xl p-3 min-w-[260px] shadow-md flex-1 ${
-        isOver ? 'bg-blue-100' : ''
-      }`}
+      className={`kanban-column flex-1 ${isOver ? 'is-over' : ''}`}
     >
       <h2 className="text-lg font-bold mb-2">{etapa}</h2>
       <div className="flex flex-col gap-2">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,186 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+:root {
+  --background: oklch(1.0000 0 0);
+  --foreground: oklch(0.2077 0.0398 265.7549);
+  --card: oklch(0.9842 0.0034 247.8575);
+  --card-foreground: oklch(0.2077 0.0398 265.7549);
+  --popover: oklch(0.9842 0.0034 247.8575);
+  --popover-foreground: oklch(0.2077 0.0398 265.7549);
+  --primary: oklch(0.6821 0.1180 210.0534);
+  --primary-foreground: oklch(1.0000 0 0);
+  --secondary: oklch(0.6187 0.1063 207.9675);
+  --secondary-foreground: oklch(1.0000 0 0);
+  --muted: oklch(0.9288 0.0126 255.5078);
+  --muted-foreground: oklch(0.5544 0.0407 257.4166);
+  --accent: oklch(0.5864 0.1039 215.5798);
+  --accent-foreground: oklch(1.0000 0 0);
+  --destructive: oklch(0.5771 0.2152 27.3250);
+  --destructive-foreground: oklch(1.0000 0 0);
+  --border: oklch(0.9288 0.0126 255.5078);
+  --input: oklch(0.9288 0.0126 255.5078);
+  --ring: oklch(0.6821 0.1180 210.0534);
+  --chart-1: oklch(0.6821 0.1180 210.0534);
+  --chart-2: oklch(0.7588 0.1243 208.2799);
+  --chart-3: oklch(0.8467 0.0909 206.1996);
+  --chart-4: oklch(0.9035 0.0585 205.5687);
+  --chart-5: oklch(0.9602 0.0244 206.1953);
+  --sidebar: oklch(0.9842 0.0034 247.8575);
+  --sidebar-foreground: oklch(0.2077 0.0398 265.7549);
+  --sidebar-primary: oklch(0.6821 0.1180 210.0534);
+  --sidebar-primary-foreground: oklch(1.0000 0 0);
+  --sidebar-accent: oklch(0.5864 0.1039 215.5798);
+  --sidebar-accent-foreground: oklch(1.0000 0 0);
+  --sidebar-border: oklch(0.9288 0.0126 255.5078);
+  --sidebar-ring: oklch(0.6821 0.1180 210.0534);
+  --font-sans: Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, Times New Roman, Times, serif;
+  --font-mono: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+  --radius: 0.5rem;
+  --shadow-2xs: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.06);
+  --shadow-xs: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.06);
+  --shadow-sm: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 1px 2px -1px hsl(0 0% 0% / 0.12);
+  --shadow: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 1px 2px -1px hsl(0 0% 0% / 0.12);
+  --shadow-md: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 2px 4px -1px hsl(0 0% 0% / 0.12);
+  --shadow-lg: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 4px 6px -1px hsl(0 0% 0% / 0.12);
+  --shadow-xl: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 8px 10px -1px hsl(0 0% 0% / 0.12);
+  --shadow-2xl: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.30);
+  --tracking-normal: -0.025em;
+  --spacing: 0.25rem;
+}
+
+.dark {
+  --background: oklch(0.2077 0.0398 265.7549);
+  --foreground: oklch(0.8690 0.0198 252.8943);
+  --card: oklch(0.2795 0.0368 260.0310);
+  --card-foreground: oklch(0.8690 0.0198 252.8943);
+  --popover: oklch(0.2795 0.0368 260.0310);
+  --popover-foreground: oklch(0.8690 0.0198 252.8943);
+  --primary: oklch(0.6821 0.1180 210.0534);
+  --primary-foreground: oklch(1.0000 0 0);
+  --secondary: oklch(0.6187 0.1063 207.9675);
+  --secondary-foreground: oklch(1.0000 0 0);
+  --muted: oklch(0.3717 0.0392 257.2870);
+  --muted-foreground: oklch(0.7107 0.0351 256.7878);
+  --accent: oklch(0.5864 0.1039 215.5798);
+  --accent-foreground: oklch(1.0000 0 0);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(1.0000 0 0);
+  --border: oklch(0.3717 0.0392 257.2870);
+  --input: oklch(0.3717 0.0392 257.2870);
+  --ring: oklch(0.6821 0.1180 210.0534);
+  --chart-1: oklch(0.6821 0.1180 210.0534);
+  --chart-2: oklch(0.7588 0.1243 208.2799);
+  --chart-3: oklch(0.8467 0.0909 206.1996);
+  --chart-4: oklch(0.9035 0.0585 205.5687);
+  --chart-5: oklch(0.9602 0.0244 206.1953);
+  --sidebar: oklch(0.2795 0.0368 260.0310);
+  --sidebar-foreground: oklch(0.8690 0.0198 252.8943);
+  --sidebar-primary: oklch(0.6821 0.1180 210.0534);
+  --sidebar-primary-foreground: oklch(1.0000 0 0);
+  --sidebar-accent: oklch(0.5864 0.1039 215.5798);
+  --sidebar-accent-foreground: oklch(1.0000 0 0);
+  --sidebar-border: oklch(0.3717 0.0392 257.2870);
+  --sidebar-ring: oklch(0.6821 0.1180 210.0534);
+  --font-sans: Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, Times New Roman, Times, serif;
+  --font-mono: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+  --radius: 0.5rem;
+  --shadow-2xs: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.06);
+  --shadow-xs: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.06);
+  --shadow-sm: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 1px 2px -1px hsl(0 0% 0% / 0.12);
+  --shadow: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 1px 2px -1px hsl(0 0% 0% / 0.12);
+  --shadow-md: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 2px 4px -1px hsl(0 0% 0% / 0.12);
+  --shadow-lg: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 4px 6px -1px hsl(0 0% 0% / 0.12);
+  --shadow-xl: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.12), 0rem 8px 10px -1px hsl(0 0% 0% / 0.12);
+  --shadow-2xl: 0rem 0.125rem 0.5rem 0rem hsl(0 0% 0% / 0.30);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --shadow-2xs: var(--shadow-2xs);
+  --shadow-xs: var(--shadow-xs);
+  --shadow-sm: var(--shadow-sm);
+  --shadow: var(--shadow);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-xl);
+  --shadow-2xl: var(--shadow-2xl);
+
+  --tracking-tighter: calc(var(--tracking-normal) - 0.05em);
+  --tracking-tight: calc(var(--tracking-normal) - 0.025em);
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: calc(var(--tracking-normal) + 0.025em);
+  --tracking-wider: calc(var(--tracking-normal) + 0.05em);
+  --tracking-widest: calc(var(--tracking-normal) + 0.1em);
+}
+
+body {
+  letter-spacing: var(--tracking-normal);
+}
+
+/* Estilos personalizados para el Kanban */
+.kanban-column {
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 0.75rem;
+  min-width: 16rem;
+  box-shadow: var(--shadow-md);
+}
+
+.kanban-column.is-over {
+  background-color: var(--color-secondary);
+}
+
+.kanban-card {
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.5rem;
+  box-shadow: var(--shadow-sm);
+}


### PR DESCRIPTION
## Summary
- apply theme variables on Kanban components
- add custom CSS classes for Kanban styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68766f2d59408328a11477c202810ac8